### PR TITLE
Fix: Change AVAudioSession category to playAndRecord

### DIFF
--- a/talkie/AudioService.swift
+++ b/talkie/AudioService.swift
@@ -22,7 +22,7 @@ class AudioService: NSObject, AVAudioRecorderDelegate {
 
     func startRecording() {
         do {
-            try audioSession.setCategory(.record, mode: .default, options: .defaultToSpeaker)
+            try audioSession.setCategory(.playAndRecord, mode: .default, options: .defaultToSpeaker)
             try audioSession.setActive(true)
 
             let filename = getDocumentsDirectory().appendingPathComponent("recording_\(UUID().uuidString).aiff")


### PR DESCRIPTION
The previous category `.record` was causing a crash on real devices because the `.defaultToSpeaker` option is only compatible with the `.playAndRecord` category. This commit fixes the issue by changing the category to `.playAndRecord`.