### PR TITLE
Fix: CarPlay CPGridButton syntax

### DIFF
--- a/talkie/CarPlaySceneDelegate.swift
+++ b/talkie/CarPlaySceneDelegate.swift
@@ -38,7 +38,7 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
 
     private func updateRecordingTemplate() {
         let title = viewModel.isRecording ? "Recording..." : "Ready to Record"
-        let recordButton = CPGridButton(title: viewModel.isRecording ? "Stop" : "Record", image: UIImage(systemName: "mic.fill")!, handler: { [weak self] _ in
+        let recordButton = CPGridButton(titleVariants: [viewModel.isRecording ? "Stop" : "Record"], image: UIImage(systemName: "mic.fill")!, handler: { [weak self] _ in
             self?.viewModel.isRecording ?? false ? self?.viewModel.stopRecording() : self?.viewModel.startRecording()
             self?.updateRecordingTemplate()
         })


### PR DESCRIPTION
This commit fixes a build error in the CarPlay extension by correcting the syntax for creating a `CPGridButton`.

- Wraps the `title` parameter in an array and changes the argument label to `titleVariants`.